### PR TITLE
test: stabilize time-dependent usage fixtures

### DIFF
--- a/src-tauri/src/providers/claude/local_usage.rs
+++ b/src-tauri/src/providers/claude/local_usage.rs
@@ -553,10 +553,12 @@ mod tests {
     fn provider_fixture_parses_and_deduplicates_claude_usage_lines() {
         let events = parse_jsonl(include_str!("fixtures/usage.jsonl"));
         assert_eq!(events.len(), 2);
+        let now =
+            events.iter().map(|event| event.timestamp).max().unwrap() + chrono::Duration::days(1);
         let events = deduplicate(events);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].total_tokens(), 170);
-        let history = aggregate(events, chrono::Utc::now(), &test_bundled_pricing());
+        let history = aggregate(events, now, &test_bundled_pricing());
         assert!(history.last_30_days.unwrap().estimated_cost_usd.is_some());
     }
 

--- a/src/lib/pacing.test.ts
+++ b/src/lib/pacing.test.ts
@@ -91,9 +91,10 @@ describe('quota pacing', () => {
       'Resets in 1h',
     );
     expect(formatReset(new Date(now - 1).toISOString(), now, 'exact')).toBe('Resets soon');
-    expect(formatReset(new Date(now + 30 * 60 * 60_000).toISOString(), now, 'exact')).toContain(
-      'Resets tomorrow at',
-    );
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(12, 0, 0, 0);
+    expect(formatReset(tomorrow.toISOString(), now, 'exact')).toContain('Resets tomorrow at');
     expect(formatReset(new Date(now + 72 * 60 * 60_000).toISOString(), now, 'exact')).toMatch(
       /^Resets .+ at /,
     );


### PR DESCRIPTION
## Summary

- make the Claude usage fixture test derive its reference time from the fixture data
- make the frontend tomorrow-label test construct the next local calendar day

These test-only changes remove clock and time-zone dependent CI failures without changing the GitHub Actions workflow.